### PR TITLE
Add initial set of tools to the allow list

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+    "permissions": {
+        "allow": [
+            "Bash(git:*)",
+            "Bash(ls:*)",
+            "Bash(cat:*)",
+            "Bash(rg:*)",
+            "Bash(head:*)",
+            "Bash(tail:*)",
+            "Bash(sed:*)",
+            "ReadFile:*",
+            "WriteFile:*",
+            "DeleteFile:*",
+            "Bun:*"
+        ]
+    }
+}


### PR DESCRIPTION
This pull request adds a new `.claude/settings.json` configuration file to define explicit permissions for various commands and file operations.

Permissions configuration:

* Added `.claude/settings.json` to specify allowed commands and file operations, including Bash commands (`git`, `ls`, `cat`, `rg`, `head`, `tail`, `sed`) and file operations (`ReadFile`, `WriteFile`, `DeleteFile`, `Bun`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration file to set up command and file operation permissions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->