### PR TITLE
Add endpoint for fetching user repository details

### DIFF
--- a/api/Promptyard.Api.IntegrationTests/FetchUserRepositoryEndpointTests.cs
+++ b/api/Promptyard.Api.IntegrationTests/FetchUserRepositoryEndpointTests.cs
@@ -1,0 +1,50 @@
+using Alba;
+using Promptyard.Api.Repositories;
+
+namespace Promptyard.Api.IntegrationTests;
+
+[ClassDataSource<AlbaBootstrap>(Shared = SharedType.PerTestSession)]
+public class FetchUserRepositoryEndpointTests(AlbaBootstrap bootstrap) : AlbaTestBase(bootstrap)
+{
+    [Test]
+    public async Task FetchUserRepository_WhenUserHasNoRepository_ReturnsNotFound()
+    {
+        await Host.Scenario(_ =>
+        {
+            _.Get.Url("/api/repository/user");
+            _.StatusCodeShouldBe(404);
+        });
+    }
+
+    [Test]
+    [DependsOn(nameof(FetchUserRepository_WhenUserHasNoRepository_ReturnsNotFound))]
+    public async Task FetchUserRepository_WhenUserHasRepository_ReturnsRepositoryDetails()
+    {
+        var onboardingDetails = new
+        {
+            FullName = "Test User",
+            Introduction = "Testing the fetch endpoint"
+        };
+
+        // Onboard the user (may already be onboarded by another test)
+        await Host.Scenario(_ =>
+        {
+            _.Post.Json(onboardingDetails).ToUrl("/api/repository/user");
+        });
+
+        // Fetch the user repository
+        var result = await Host.Scenario(_ =>
+        {
+            _.Get.Url("/api/repository/user");
+            _.StatusCodeShouldBe(200);
+        });
+
+        var userRepository = result.ReadAsJson<UserRepositoryDetails>();
+
+        await Assert.That(userRepository).IsNotNull();
+        await Assert.That(userRepository!.Id).IsNotEqualTo(Guid.Empty);
+        await Assert.That(userRepository.UserId).IsEqualTo("test-user");
+        await Assert.That(userRepository.Name).IsNotEmpty();
+        await Assert.That(userRepository.Slug).IsNotEmpty();
+    }
+}

--- a/api/Promptyard.Api/Program.cs
+++ b/api/Promptyard.Api/Program.cs
@@ -58,6 +58,7 @@ app.UseOutputCache();
 
 app.MapWolverineEndpoints(options =>
 {
+    options.WarmUpRoutes = RouteWarmup.Eager;
     options.UseFluentValidationProblemDetailMiddleware();
 });
 

--- a/api/Promptyard.Api/Repositories/FetchUserRepositoryEndpoint.cs
+++ b/api/Promptyard.Api/Repositories/FetchUserRepositoryEndpoint.cs
@@ -1,0 +1,23 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Wolverine.Http;
+
+namespace Promptyard.Api.Repositories;
+
+public class FetchUserRepositoryEndpoint
+{
+    [Authorize]
+    [WolverineGet("/api/repository/user")]
+    public static async Task<IResult> GetAsync(ClaimsPrincipal user, IUserRepositoryLookup repositoryLookup)
+    {
+        var userId = user.Identity!.Name!;
+        var userRepository = await repositoryLookup.GetByUserIdAsync(userId);
+
+        if (userRepository is null)
+        {
+            return Results.NotFound();
+        }
+
+        return Results.Ok(userRepository);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `GET /api/repository/user` endpoint to retrieve the authenticated user's repository details
- Returns `UserRepositoryDetails` (Id, UserId, Name, Slug, Description) on success
- Returns 404 if the user hasn't been onboarded yet
- Adds eager route warmup to fix Wolverine.Http startup issue

Closes #74

## Test plan
- [x] Integration test verifies 404 when user has no repository
- [x] Integration test verifies 200 with correct data when user has a repository
- [x] All existing tests pass (14 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)