### PR TITLE
Add unit tests for RepositorySlugGenerator

### DIFF
--- a/api/Promptyard.Api.Tests/Repositories/RepositorySlugGeneratorTests.cs
+++ b/api/Promptyard.Api.Tests/Repositories/RepositorySlugGeneratorTests.cs
@@ -1,0 +1,240 @@
+using FakeItEasy;
+using Promptyard.Api.Repositories;
+
+namespace Promptyard.Api.Tests.Repositories;
+
+public class RepositorySlugGeneratorTests
+{
+    private readonly IRepositoryLookup _repositoryLookup;
+    private readonly RepositorySlugGenerator _sut;
+
+    public RepositorySlugGeneratorTests()
+    {
+        _repositoryLookup = A.Fake<IRepositoryLookup>();
+        _sut = new RepositorySlugGenerator(_repositoryLookup);
+    }
+
+    [Test]
+    public async Task GenerateSlugWithSimpleNameReturnsLowercaseSlug()
+    {
+        SetupNoCollisions();
+
+        var result = _sut.GenerateSlug("John Doe");
+
+        await Assert.That(result).IsEqualTo("john-doe");
+    }
+
+    [Test]
+    public async Task GenerateSlugWithUppercaseNameReturnsLowercaseSlug()
+    {
+        SetupNoCollisions();
+
+        var result = _sut.GenerateSlug("JOHN DOE");
+
+        await Assert.That(result).IsEqualTo("john-doe");
+    }
+
+    [Test]
+    public async Task GenerateSlugWithMultipleSpacesCollapsesToSingleHyphen()
+    {
+        SetupNoCollisions();
+
+        var result = _sut.GenerateSlug("John  Doe");
+
+        await Assert.That(result).IsEqualTo("john-doe");
+    }
+
+    [Test]
+    public async Task GenerateSlugWithManySpacesCollapsesToSingleHyphen()
+    {
+        SetupNoCollisions();
+
+        var result = _sut.GenerateSlug("John     Doe");
+
+        await Assert.That(result).IsEqualTo("john-doe");
+    }
+
+    [Test]
+    public async Task GenerateSlugWithUnderscoreConvertsToHyphen()
+    {
+        SetupNoCollisions();
+
+        var result = _sut.GenerateSlug("John_Doe");
+
+        await Assert.That(result).IsEqualTo("john-doe");
+    }
+
+    [Test]
+    public async Task GenerateSlugWithMultipleUnderscoresCollapsesToSingleHyphen()
+    {
+        SetupNoCollisions();
+
+        var result = _sut.GenerateSlug("John___Doe");
+
+        await Assert.That(result).IsEqualTo("john-doe");
+    }
+
+    [Test]
+    public async Task GenerateSlugWithMixedSpacesAndUnderscoresCollapsesToSingleHyphen()
+    {
+        SetupNoCollisions();
+
+        var result = _sut.GenerateSlug("John _ Doe");
+
+        await Assert.That(result).IsEqualTo("john-doe");
+    }
+
+    [Test]
+    public async Task GenerateSlugWithSpecialCharactersRemovesThem()
+    {
+        SetupNoCollisions();
+
+        var result = _sut.GenerateSlug("@John#Doe!");
+
+        await Assert.That(result).IsEqualTo("johndoe");
+    }
+
+    [Test]
+    public async Task GenerateSlugWithSpecialCharactersAndSpacesHandlesBoth()
+    {
+        SetupNoCollisions();
+
+        var result = _sut.GenerateSlug("John @#$ Doe");
+
+        await Assert.That(result).IsEqualTo("john-doe");
+    }
+
+    [Test]
+    public async Task GenerateSlugWithNumbersPreservesThem()
+    {
+        SetupNoCollisions();
+
+        var result = _sut.GenerateSlug("John123Doe");
+
+        await Assert.That(result).IsEqualTo("john123doe");
+    }
+
+    [Test]
+    public async Task GenerateSlugWithLeadingSpacesTrimsInput()
+    {
+        SetupNoCollisions();
+
+        var result = _sut.GenerateSlug("  John Doe");
+
+        await Assert.That(result).IsEqualTo("john-doe");
+    }
+
+    [Test]
+    public async Task GenerateSlugWithTrailingSpacesTrimsInput()
+    {
+        SetupNoCollisions();
+
+        var result = _sut.GenerateSlug("John Doe  ");
+
+        await Assert.That(result).IsEqualTo("john-doe");
+    }
+
+    [Test]
+    public async Task GenerateSlugWithLeadingHyphensRemovesThem()
+    {
+        SetupNoCollisions();
+
+        var result = _sut.GenerateSlug("-John Doe");
+
+        await Assert.That(result).IsEqualTo("john-doe");
+    }
+
+    [Test]
+    public async Task GenerateSlugWithTrailingHyphensRemovesThem()
+    {
+        SetupNoCollisions();
+
+        var result = _sut.GenerateSlug("John Doe-");
+
+        await Assert.That(result).IsEqualTo("john-doe");
+    }
+
+    [Test]
+    public async Task GenerateSlugWithLeadingAndTrailingHyphensRemovesBoth()
+    {
+        SetupNoCollisions();
+
+        var result = _sut.GenerateSlug("---John Doe---");
+
+        await Assert.That(result).IsEqualTo("john-doe");
+    }
+
+    [Test]
+    public async Task GenerateSlugWithLeadingSpecialCharactersHandlesCorrectly()
+    {
+        SetupNoCollisions();
+
+        var result = _sut.GenerateSlug("@#$John Doe");
+
+        await Assert.That(result).IsEqualTo("john-doe");
+    }
+
+    [Test]
+    public async Task GenerateSlugWithCollisionAppendsNumericSuffix()
+    {
+        SetupCollisionCount(1);
+
+        var result = _sut.GenerateSlug("John Doe");
+
+        await Assert.That(result).IsEqualTo("john-doe-1");
+    }
+
+    [Test]
+    public async Task GenerateSlugWithMultipleCollisionsAppendsCorrectSuffix()
+    {
+        SetupCollisionCount(5);
+
+        var result = _sut.GenerateSlug("John Doe");
+
+        await Assert.That(result).IsEqualTo("john-doe-5");
+    }
+
+    [Test]
+    public async Task GenerateSlugWithNoCollisionsReturnsBasicSlug()
+    {
+        SetupNoCollisions();
+
+        var result = _sut.GenerateSlug("John Doe");
+
+        await Assert.That(result).IsEqualTo("john-doe");
+    }
+
+    [Test]
+    public async Task GenerateSlugWithRepositoryIdPassesIdToLookup()
+    {
+        var repositoryId = Guid.NewGuid();
+        SetupNoCollisions();
+
+        _sut.GenerateSlug("John Doe", repositoryId);
+
+        A.CallTo(() => _repositoryLookup.CountBySlugPrefix("john-doe", repositoryId))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public async Task GenerateSlugWithoutRepositoryIdPassesNullToLookup()
+    {
+        SetupNoCollisions();
+
+        _sut.GenerateSlug("John Doe");
+
+        A.CallTo(() => _repositoryLookup.CountBySlugPrefix("john-doe", null))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    private void SetupNoCollisions()
+    {
+        SetupCollisionCount(0);
+    }
+
+    private void SetupCollisionCount(int count)
+    {
+        A.CallTo(() => _repositoryLookup.CountBySlugPrefix(A<string>.Ignored, A<Guid?>.Ignored))
+            .Returns(count);
+    }
+}

--- a/api/Promptyard.Api/Program.cs
+++ b/api/Promptyard.Api/Program.cs
@@ -55,6 +55,7 @@ builder.Services
 builder.Services.AddAuthorization();
 
 builder.Services.AddTransient<IRepositorySlugGenerator, RepositorySlugGenerator>();
+builder.Services.AddTransient<IRepositoryLookup, RepositoryLookup>();
 builder.Services.AddTransient<IUserRepositoryLookup, UserRepositoryLookup>();
 
 var app = builder.Build();

--- a/api/Promptyard.Api/Repositories/IRepositoryLookup.cs
+++ b/api/Promptyard.Api/Repositories/IRepositoryLookup.cs
@@ -1,0 +1,6 @@
+namespace Promptyard.Api.Repositories;
+
+public interface IRepositoryLookup
+{
+    int CountBySlugPrefix(string slugPrefix, Guid? excludeRepositoryId = null);
+}

--- a/api/Promptyard.Api/Repositories/RepositoryLookup.cs
+++ b/api/Promptyard.Api/Repositories/RepositoryLookup.cs
@@ -1,0 +1,20 @@
+using Marten;
+
+namespace Promptyard.Api.Repositories;
+
+public class RepositoryLookup(IDocumentSession session) : IRepositoryLookup
+{
+    public int CountBySlugPrefix(string slugPrefix, Guid? excludeRepositoryId = null)
+    {
+        var query = session
+            .Query<RepositoryDetails>()
+            .Where(x => x.Slug.StartsWith(slugPrefix));
+
+        if (excludeRepositoryId != null)
+        {
+            query = query.Where(x => x.Id != excludeRepositoryId);
+        }
+
+        return query.Count();
+    }
+}

--- a/api/Promptyard.Api/Repositories/RepositorySlugGenerator.cs
+++ b/api/Promptyard.Api/Repositories/RepositorySlugGenerator.cs
@@ -1,5 +1,4 @@
 ﻿using System.Text.RegularExpressions;
-using Marten;
 
 namespace Promptyard.Api.Repositories;
 
@@ -8,22 +7,13 @@ public interface IRepositorySlugGenerator
     string GenerateSlug(string name, Guid? repositoryId = null);
 }
 
-public class RepositorySlugGenerator(IDocumentSession session) : IRepositorySlugGenerator
+public class RepositorySlugGenerator(IRepositoryLookup repositoryLookup) : IRepositorySlugGenerator
 {
     public string GenerateSlug(string name, Guid? repositoryId = null)
     {
         var generatedSlug = GenerateRawSlug(name);
 
-        var collidingSlugs = session
-            .Query<RepositoryDetails>()
-            .Where(x => x.Slug.StartsWith(generatedSlug));
-
-        if (repositoryId != null)
-        {
-            collidingSlugs = collidingSlugs.Where(x => x.Id != repositoryId);
-        }
-
-        var slugCount = collidingSlugs.Count();
+        var slugCount = repositoryLookup.CountBySlugPrefix(generatedSlug, repositoryId);
 
         if (slugCount > 0)
         {


### PR DESCRIPTION
## Summary
- Add 21 unit tests for `RepositorySlugGenerator` covering all acceptance criteria
- Extract `IRepositoryLookup` interface to improve testability by replacing direct `IDocumentSession` dependency
- Add `RepositoryLookup` implementation that encapsulates the Marten query logic

## Test coverage
- Basic slug generation (e.g., `"John Doe"` → `"john-doe"`)
- Multiple spaces handling (e.g., `"John  Doe"` → `"john-doe"`)
- Underscore conversion (e.g., `"John_Doe"` → `"john-doe"`)
- Special character removal (e.g., `"@John#Doe!"` → `"johndoe"`)
- Leading/trailing hyphen trimming
- Collision detection with numeric suffix generation
- Repository ID exclusion parameter

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)