### PR TITLE
Add tags to agents

### DIFF
--- a/api/Promptyard.Api.Tests/Agents/AddAgentToRepositoryRequestValidatorTests.cs
+++ b/api/Promptyard.Api.Tests/Agents/AddAgentToRepositoryRequestValidatorTests.cs
@@ -1,0 +1,118 @@
+using FluentValidation.TestHelper;
+using Promptyard.Api.Agents;
+
+namespace Promptyard.Api.Tests.Features.Agents;
+
+public class AddAgentToRepositoryRequestValidatorTests
+{
+    [Test]
+    public async Task ValidateWithValidRequestReturnsTrue()
+    {
+        var validator = new AddAgentToRepositoryRequestValidator();
+        var request = new AddAgentToRepositoryRequest("Test Agent", "A test agent description", null);
+        var result = await validator.TestValidateAsync(request);
+
+        await Assert.That(result.IsValid).IsTrue();
+    }
+
+    [Test]
+    public async Task ValidateWithEmptyNameReturnsFalse()
+    {
+        var validator = new AddAgentToRepositoryRequestValidator();
+        var request = new AddAgentToRepositoryRequest("", "A test agent description", null);
+        var result = await validator.TestValidateAsync(request);
+
+        await Assert.That(result.IsValid).IsFalse();
+    }
+
+    [Test]
+    public async Task ValidateWithTooLongNameReturnsFalse()
+    {
+        var validator = new AddAgentToRepositoryRequestValidator();
+        var request = new AddAgentToRepositoryRequest(new string('a', 201), "A test agent description", null);
+        var result = await validator.TestValidateAsync(request);
+
+        await Assert.That(result.IsValid).IsFalse();
+    }
+
+    [Test]
+    public async Task ValidateWithNullDescriptionReturnsTrue()
+    {
+        var validator = new AddAgentToRepositoryRequestValidator();
+        var request = new AddAgentToRepositoryRequest("Test Agent", null, null);
+        var result = await validator.TestValidateAsync(request);
+
+        await Assert.That(result.IsValid).IsTrue();
+    }
+
+    [Test]
+    public async Task ValidateWithTooLongDescriptionReturnsFalse()
+    {
+        var validator = new AddAgentToRepositoryRequestValidator();
+        var request = new AddAgentToRepositoryRequest("Test Agent", new string('a', 1001), null);
+        var result = await validator.TestValidateAsync(request);
+
+        await Assert.That(result.IsValid).IsFalse();
+    }
+
+    [Test]
+    public async Task ValidateWithValidTagsReturnsTrue()
+    {
+        var validator = new AddAgentToRepositoryRequestValidator();
+        var request = new AddAgentToRepositoryRequest("Test Agent", "Description", ["tag1", "tag2", "tag3"]);
+        var result = await validator.TestValidateAsync(request);
+
+        await Assert.That(result.IsValid).IsTrue();
+    }
+
+    [Test]
+    public async Task ValidateWithTooManyTagsReturnsFalse()
+    {
+        var validator = new AddAgentToRepositoryRequestValidator();
+        var tags = Enumerable.Range(1, 11).Select(i => $"tag{i}").ToArray();
+        var request = new AddAgentToRepositoryRequest("Test Agent", "Description", tags);
+        var result = await validator.TestValidateAsync(request);
+
+        await Assert.That(result.IsValid).IsFalse();
+    }
+
+    [Test]
+    public async Task ValidateWithEmptyTagReturnsFalse()
+    {
+        var validator = new AddAgentToRepositoryRequestValidator();
+        var request = new AddAgentToRepositoryRequest("Test Agent", "Description", ["valid", "", "another"]);
+        var result = await validator.TestValidateAsync(request);
+
+        await Assert.That(result.IsValid).IsFalse();
+    }
+
+    [Test]
+    public async Task ValidateWithTooLongTagReturnsFalse()
+    {
+        var validator = new AddAgentToRepositoryRequestValidator();
+        var request = new AddAgentToRepositoryRequest("Test Agent", "Description", [new string('a', 51)]);
+        var result = await validator.TestValidateAsync(request);
+
+        await Assert.That(result.IsValid).IsFalse();
+    }
+
+    [Test]
+    public async Task ValidateWithNullTagsReturnsTrue()
+    {
+        var validator = new AddAgentToRepositoryRequestValidator();
+        var request = new AddAgentToRepositoryRequest("Test Agent", "Description", null);
+        var result = await validator.TestValidateAsync(request);
+
+        await Assert.That(result.IsValid).IsTrue();
+    }
+
+    [Test]
+    public async Task ValidateWithEmptyTagsArrayReturnsTrue()
+    {
+        var validator = new AddAgentToRepositoryRequestValidator();
+        var request = new AddAgentToRepositoryRequest("Test Agent", "Description", []);
+        var result = await validator.TestValidateAsync(request);
+
+        await Assert.That(result.IsValid).IsTrue();
+    }
+}

--- a/api/Promptyard.Api.Tests/Agents/FetchAgentsFromRepositoryEndpointTests.cs
+++ b/api/Promptyard.Api.Tests/Agents/FetchAgentsFromRepositoryEndpointTests.cs
@@ -19,8 +19,8 @@ public class FetchAgentsFromRepositoryEndpointTests
         {
             var agents = new List<AgentDetails>
             {
-                new(Guid.NewGuid(), _repositoryId, "test-repo", "Agent 1", "Description 1"),
-                new(Guid.NewGuid(), _repositoryId, "test-repo", "Agent 2", null)
+                new(Guid.NewGuid(), _repositoryId, "test-repo", "Agent 1", "Description 1", ["tag1", "tag2"]),
+                new(Guid.NewGuid(), _repositoryId, "test-repo", "Agent 2", null, [])
             };
 
             _expectedResult = new PagedResult<AgentDetails>(agents, 1, 20, 2);

--- a/api/Promptyard.Api/Agents/AddAgentToRepositoryEndpoint.cs
+++ b/api/Promptyard.Api/Agents/AddAgentToRepositoryEndpoint.cs
@@ -1,0 +1,92 @@
+using FluentValidation;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Promptyard.Api.Repositories;
+using Wolverine.Http;
+using Wolverine.Marten;
+
+namespace Promptyard.Api.Agents;
+
+public record AddAgentToRepositoryRequest(string Name, string? Description, string[]? Tags);
+
+public class AddAgentToRepositoryRequestValidator : AbstractValidator<AddAgentToRepositoryRequest>
+{
+    private const int MaxTagCount = 10;
+    private const int MaxTagLength = 50;
+
+    public AddAgentToRepositoryRequestValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(200);
+
+        RuleFor(x => x.Description)
+            .MaximumLength(1000);
+
+        RuleFor(x => x.Tags)
+            .Must(tags => tags is null || tags.Length <= MaxTagCount)
+            .WithMessage($"An agent can have a maximum of {MaxTagCount} tags.");
+
+        RuleForEach(x => x.Tags)
+            .NotEmpty()
+            .WithMessage("Tags cannot be empty.")
+            .MaximumLength(MaxTagLength)
+            .WithMessage($"Each tag must be at most {MaxTagLength} characters.")
+            .When(x => x.Tags is not null);
+    }
+}
+
+public class AddAgentToRepositoryEndpoint
+{
+    public static async Task<ProblemDetails?> ValidateAsync(
+        string slug,
+        IRepositoryLookup repositoryLookup)
+    {
+        var repository = await repositoryLookup.GetBySlugAsync(slug);
+
+        if (repository is null)
+        {
+            return new ProblemDetails
+            {
+                Title = "Repository not found",
+                Detail = $"No repository was found with slug '{slug}'.",
+                Status = StatusCodes.Status404NotFound
+            };
+        }
+
+        return WolverineContinue.NoProblems;
+    }
+
+    [Authorize]
+    [WolverinePost("/api/repository/{slug}/agents")]
+    public static async Task<(AgentDetails, AgentCreated, IStartStream)> ExecuteAsync(
+        string slug,
+        AddAgentToRepositoryRequest request,
+        IRepositoryLookup repositoryLookup)
+    {
+        var repository = await repositoryLookup.GetBySlugAsync(slug);
+
+        var agentId = Guid.NewGuid();
+        var tags = request.Tags ?? [];
+
+        var agentCreated = new AgentCreated(
+            agentId,
+            repository!.Id,
+            repository.Slug,
+            request.Name,
+            request.Description,
+            tags);
+
+        var startStream = MartenOps.StartStream<Agent>(agentId, agentCreated);
+
+        var response = new AgentDetails(
+            agentId,
+            repository.Id,
+            repository.Slug,
+            request.Name,
+            request.Description,
+            tags);
+
+        return (response, agentCreated, startStream);
+    }
+}

--- a/api/Promptyard.Api/Agents/Agent.cs
+++ b/api/Promptyard.Api/Agents/Agent.cs
@@ -6,6 +6,7 @@ public class Agent
     public Guid RepositoryId { get; private set; }
     public string Name { get; private set; } = null!;
     public string? Description { get; private set; }
+    public string[] Tags { get; private set; } = [];
 
     private void Apply(AgentCreated agentCreated)
     {
@@ -13,5 +14,6 @@ public class Agent
         RepositoryId = agentCreated.RepositoryId;
         Name = agentCreated.Name;
         Description = agentCreated.Description;
+        Tags = agentCreated.Tags;
     }
 }

--- a/api/Promptyard.Api/Agents/AgentCreated.cs
+++ b/api/Promptyard.Api/Agents/AgentCreated.cs
@@ -5,4 +5,5 @@ public record AgentCreated(
     Guid RepositoryId,
     string RepositorySlug,
     string Name,
-    string? Description);
+    string? Description,
+    string[] Tags);

--- a/api/Promptyard.Api/Agents/AgentDetails.cs
+++ b/api/Promptyard.Api/Agents/AgentDetails.cs
@@ -5,4 +5,5 @@ public record AgentDetails(
     Guid RepositoryId,
     string RepositorySlug,
     string Name,
-    string? Description);
+    string? Description,
+    string[] Tags);

--- a/api/Promptyard.Api/Agents/AgentDetailsProjection.cs
+++ b/api/Promptyard.Api/Agents/AgentDetailsProjection.cs
@@ -12,6 +12,7 @@ public class AgentDetailsProjection : EventProjection
             @event.RepositoryId,
             @event.RepositorySlug,
             @event.Name,
-            @event.Description));
+            @event.Description,
+            @event.Tags));
     }
 }


### PR DESCRIPTION
This PR adds a tags field to the agent content with the same validations as we used for skills.